### PR TITLE
fix-formatJsonWithGqlQuery

### DIFF
--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-def versionName = "1.0"
+def versionName = "1.0.1"
 
 publishing {
     publications {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FormatUtils.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/FormatUtils.kt
@@ -128,7 +128,7 @@ internal object FormatUtils {
             }
             if (doc != null) {
                 val formattedGql = AstPrinter.printAst(doc)
-                json.replace(gqlQueryRegex, formattedGql)
+                json.replace(matchResult.value, formattedGql)
             } else {
                 json
             }


### PR DESCRIPTION
The logger removes the $ symbol from the request text in the log.
A batch request, the names of the variables in the variables blocks change, but the query lines themselves always indicate variables
